### PR TITLE
doc: correct list orders

### DIFF
--- a/docs/architecture/cloud-storage/observability/index.md
+++ b/docs/architecture/cloud-storage/observability/index.md
@@ -11,8 +11,8 @@ CobaltCore monitors the cloud storage stack through a combination of Prometheus-
 
 | Component | Role |
 |-----------|------|
-| [Prometheus](./prometheus.md) | Scrapes and stores time-series metrics from Ceph, Rook, and RGW exporters |
 | [Perses](./perses.md) | Dashboard platform for visualizing storage metrics (alert rules are defined as Prometheus rules) |
+| [Prometheus](./prometheus.md) | Scrapes and stores time-series metrics from Ceph, Rook, and RGW exporters |
 | [Prysm](./prysm.md) | CLI-based observability tool for Ceph clusters and RGW — real-time monitoring, SMART disk health, log compliance |
 
 ## Key Metrics
@@ -33,6 +33,6 @@ Alerts are defined as Prometheus rules and surfaced through the CobaltCore alert
 
 ## See Also
 
-- [Prometheus](./prometheus.md)
 - [Perses](./perses.md)
+- [Prometheus](./prometheus.md)
 - [Prysm](./prysm.md)


### PR DESCRIPTION
Correct the orders of two lists of observability tools so that they are congruent with one another, as per the direction of Barbara Wendt.