### PR TITLE
docs: correct Observability list order

### DIFF
--- a/docs/architecture/cloud-storage/observability/index.md
+++ b/docs/architecture/cloud-storage/observability/index.md
@@ -11,9 +11,9 @@ CobaltCore monitors the cloud storage stack through a combination of Prometheus-
 
 | Component | Role |
 |-----------|------|
+| [Prysm](./prysm.md) | CLI-based observability tool for Ceph clusters and RGW — real-time monitoring, SMART disk health, log compliance |
 | [Prometheus](./prometheus.md) | Scrapes and stores time-series metrics from Ceph, Rook, and RGW exporters |
 | [Perses](./perses.md) | Dashboard platform for visualizing storage metrics (alert rules are defined as Prometheus rules) |
-| [Prysm](./prysm.md) | CLI-based observability tool for Ceph clusters and RGW — real-time monitoring, SMART disk health, log compliance |
 
 ## Key Metrics
 
@@ -33,6 +33,6 @@ Alerts are defined as Prometheus rules and surfaced through the CobaltCore alert
 
 ## See Also
 
+- [Prysm](./prysm.md)
 - [Prometheus](./prometheus.md)
 - [Perses](./perses.md)
-- [Prysm](./prysm.md)

--- a/docs/architecture/cloud-storage/observability/perses.md
+++ b/docs/architecture/cloud-storage/observability/perses.md
@@ -1,5 +1,6 @@
 ---
 title: Perses
+order: 30
 ---
 
 # Perses

--- a/docs/architecture/cloud-storage/observability/prometheus.md
+++ b/docs/architecture/cloud-storage/observability/prometheus.md
@@ -1,5 +1,6 @@
 ---
 title: Prometheus
+order: 20
 ---
 
 # Prometheus

--- a/docs/architecture/cloud-storage/observability/prysm.md
+++ b/docs/architecture/cloud-storage/observability/prysm.md
@@ -1,5 +1,6 @@
 ---
 title: Prysm 
+order: 10
 ---
 
 # Prysm 

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -5,7 +5,7 @@ title: Changelog
 # Change Log
 
 | Date          | Change                        | git hash  |
-| :---          | :---                          |           |
+| :---          | :---                          | :---       |
 | 2025-11-26    | Add ceph.md, an overview page that explains the function and purpose of Ceph                   | a01c4435  |
 | 2026-03-03    | Add a page that explains how to use Rook, a tool for deploying Ceph                 | 499a3a76  |
 | 2026-03-04    | Add documentation for Prysm, a CLI tool for real-time monitoring of RGW, Ceph storage clusters, and various hardware components.       | deeb3ea8  |


### PR DESCRIPTION
Correct the order of the items in the list of Prysm, Prometheus, and Perses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reordered observability documentation so Prysm appears before Prometheus and Perses.
  * Added consistent ordering metadata to the Prysm, Prometheus, and Perses documentation pages.
  * Updated related navigation links to reflect the new page order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->